### PR TITLE
Update GitHub Actions tags to digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           path: accelerator-ci
       - name: Checkout CLI
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           repository: pivotal/acc-engine
           ssh-key: ${{ secrets.ACC_SSH }}
           path: acc-engine
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1
         with:
           java-version: '11'
       - name: Install YTT
@@ -40,7 +40,7 @@ jobs:
           cd acc-engine/cli
           java -jar target/cli-1.3.0-SNAPSHOT-exec.jar run --values ../../accelerator-ci/accelerator-test/values.json --output ../../generated-project hello-spring
       - name: Upload Generated Project
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3
         with:
           name: generated-project
           path: generated-project
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download generated project
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: generated-project
       - name: Compile
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download generated project
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: generated-project
       - name: Test
@@ -76,7 +76,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download generated project
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: generated-project
       - name: Get grype


### PR DESCRIPTION
This PR changes the projects GitHub Actions tags to digests.

For more details, refer to the [GitHubs documentation on security hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

To automate this process and keep up to date, you can also use [Minder](https://cloud.stacklok.com),the open-source DevSecOps platform. Stacklok offers a free-for-open-source hosted version.

Full disclosure: I am an open source dev working at Stacklok on the [Minder Open source project](https://github.com/stacklok/minder), aiming to help secure the open source software.

If you don't feel you need this, please just go ahead and close and I will not bother you again.
